### PR TITLE
Error console opner functionality, removal of old trusted domains

### DIFF
--- a/data/addon-config.json
+++ b/data/addon-config.json
@@ -1,14 +1,8 @@
 {
   "trustedOrigins": [
+	"http://flightdeck.zalewa.info/",
     "https://builder-addons.allizom.org",
     "https://builder-addons-next.allizom.org",
-    "https://builder.addons.mozilla.org/",
-    "https://builder.mozillalabs.com",
-    "https://lm-app-flightdeck-dev01.labs.mozilla.org",
-    "https://lm-app-flightdeck-dev01.mozillalabs.com",
-    "https://lm-app-flightdeck-stage01.labs.mozilla.org",
-    "https://lm-app-flightdeck-stage01.mozillalabs.com",
-    "https://lm-app-flightdeck01.labs.mozilla.org",
-    "https://lm-app-flightdeck01.mozillalabs.com"
+    "https://builder.addons.mozilla.org/"
   ]
 }

--- a/lib/addons-builder-helper.js
+++ b/lib/addons-builder-helper.js
@@ -2,6 +2,10 @@ var file = require("file");
 var shellUtils = require("shell-utils");
 var print;
 
+var {Cc,Ci} = require('chrome');
+var windowManager = Cc['@mozilla.org/appshell/window-mediator;1'].getService(Ci.nsIWindowMediator);
+var consoleWindow = null;
+
 const CONFIG_FILENAME = "addon-config.json";
 const CONFIG_PREF = "extensions.addonBuilderHelper.trustedOrigins";
 
@@ -65,6 +69,23 @@ function attachApiToChannel(channel, addonManager) {
       addonManager.install(data.contents);
       return {success: true,
               msg: "installed"};
+	case "toggleConsole":
+		consoleWindow = windowManager.getMostRecentWindow('global:console');
+		var message = null;
+		switch(data.contents){
+			case 'open': consoleWindow = (consoleWindow) ? consoleWindow.focus() : windowManager.getMostRecentWindow(null).open('chrome://global/content/console.xul', '_blank', 'chrome,extrachrome,menubar,resizable,scrollbars,status,toolbar');
+				break;
+			case 'close': consoleWindow = (consoleWindow) ? consoleWindow.close() : null;
+				break;
+			case 'isOpen': message = (consoleWindow) ? true : false;
+				break;
+			default:
+				message = 'An unrecognized command was passed through the "contents" property of the mozFlightDeck send object. Available commands are "open", "close", and "isOpen"';
+		}
+		return {
+			success: true,
+			msg: message
+		};
     default:
       return {success: false,
               msg: "unknown command: " + data.cmd};


### PR DESCRIPTION
Added command to open/close of console and removed old trusted domain json entries to deprecated mozillalabs Builder URLs.
