### PR TITLE
Bug 760853: Use new PageMod flag in order to expose mozFlightdeck to already opened tabs.

### DIFF
--- a/lib/addons-builder-helper.js
+++ b/lib/addons-builder-helper.js
@@ -193,6 +193,7 @@ exports.main = function main() {
 
   PageMod({
     include: config.trustedOrigins,
+    attachTo: ["existing", "top"],
     contentScriptWhen: "start",
     contentScript: "new " + function ContentScriptScope() {
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=760853
