### PR TITLE
Bug 883123 - Add private-browsing flag to ABH's package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
     "main": "addons-builder-helper",
     "fullName": "Add-on Builder Helper",
     "id": "jid0-t3eeRQgGANLCH9c50lPqcTDuNng",
+    "permissions": {"private-browsing": true}, 
     "description": "Add-on Builder Helper helps you use Add-on Builder, Mozilla's web application for building Firefox add-ons. It gives Add-on Builder the ability to install and try out add-ons as they are being developed."
 }


### PR DESCRIPTION
Without this flag, parts of the Builder website will not run if the user is using a private window, since page-mods/etc are disabled in private windows.
